### PR TITLE
chore/babel-esm

### DIFF
--- a/packages/mdx-embed/.babelrc
+++ b/packages/mdx-embed/.babelrc
@@ -1,13 +1,13 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"],
-  "plugins": [
+  "presets": [
     [
-      "@babel/plugin-transform-modules-commonjs",
+      "@babel/preset-env",
       {
-        "strictMode": false
+        "modules": false
       }
     ],
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread"
-  ]
+    "@babel/preset-react",
+    "@babel/preset-typescript"
+  ],
+  "plugins": ["@babel/plugin-proposal-class-properties", "@babel/plugin-proposal-object-rest-spread"]
 }

--- a/packages/mdx-embed/.eslintrc.js
+++ b/packages/mdx-embed/.eslintrc.js
@@ -2,13 +2,11 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
-
   extends: [
     'eslint:recommended',
     'plugin:react/recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
-    'prettier',
     'prettier/@typescript-eslint',
   ],
   settings: {
@@ -17,6 +15,7 @@ module.exports = {
     },
   },
   rules: {
+    'no-loop-func': 0,
     'react/prop-types': 0,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/ban-ts-comment': 0,
@@ -24,5 +23,16 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 0,
     '@typescript-eslint/no-empty-interface': 0,
     '@typescript-eslint/no-non-null-assertion': 0,
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+        custom: {
+          regex: '^I[A-Z]',
+          match: true,
+        },
+      },
+    ],
   },
 };

--- a/packages/mdx-embed/package.json
+++ b/packages/mdx-embed/package.json
@@ -10,7 +10,6 @@
     "build:types": "tsc",
     "build:js": "babel -d dist src --extensions=\".ts,.tsx\"",
     "build": "npm run build:types && npm run build:js",
-    "develop": "babel -d dist src --extensions=\".ts,.tsx\" -w",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
@@ -44,7 +43,6 @@
     "@babel/core": "^7.11.4",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-    "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",

--- a/packages/mdx-embed/src/components/general-observer/general-observer.tsx
+++ b/packages/mdx-embed/src/components/general-observer/general-observer.tsx
@@ -1,13 +1,13 @@
 import React, { FunctionComponent, useRef, useEffect, useState, RefObject } from 'react';
 
-interface GeneralObserverProps {
+interface IGeneralObserverProps {
   /** Fires when IntersectionObserver enters viewport */
   onEnter?: (id?: string) => void;
   /** The height of the placeholder div before the component renders in */
   height?: number;
 }
 
-export const GeneralObserver: FunctionComponent<GeneralObserverProps> = ({ children, onEnter, height = 0 }) => {
+export const GeneralObserver: FunctionComponent<IGeneralObserverProps> = ({ children, onEnter, height = 0 }) => {
   const ref = useRef<HTMLElement>(null);
   const [isChildVisible, setIsChildVisible] = useState(false);
   useEffect(() => {

--- a/packages/mdx-embed/tsconfig.json
+++ b/packages/mdx-embed/tsconfig.json
@@ -11,7 +11,7 @@
     // Set declartion to true
     "declaration": true,
     // Determine where the d.ts files are put
-    "declarationDir": "./dist/types",
+    "declarationDir": "./dist/",
     // Redirect to declarationDir
     "outDir": "./dist/",
     // Enable strictest settings like strictNullChecks & noImplicitAny.

--- a/packages/mdx-embed/tsconfig.json
+++ b/packages/mdx-embed/tsconfig.json
@@ -1,28 +1,16 @@
 {
   "compilerOptions": {
-    // Target latest version of ECMAScript.
     "target": "esnext",
-    // Search under node_modules for non-relative imports.
     "moduleResolution": "node",
-    // Process & infer types from .js files.
     "allowJs": true,
-    // Let TypeScript emit the d.ts files
     "emitDeclarationOnly": true,
-    // Set declartion to true
     "declaration": true,
-    // Determine where the d.ts files are put
     "declarationDir": "./dist/",
-    // Redirect to declarationDir
     "outDir": "./dist/",
-    // Enable strictest settings like strictNullChecks & noImplicitAny.
     "strict": true,
-    // Disallow features that require cross-file information for emit.
     "isolatedModules": true,
-    // Import non-ES modules as default imports.
     "esModuleInterop": true,
-    // Allow TypeScript to automatically compile tsx
     "jsx": "react",
-    // Allow named exports rather than export * from
     "allowSyntheticDefaultImports": true
   },
   "include": ["src"],


### PR DESCRIPTION
- change babel config to export ESM


@spences10 If you happen to speak to Chris again i think this is what we'll need but i've gotta be honest i've run out talent with Babel.

Before this PR i was transforming syntax to `cjs`, and now i've removed `@babel/plugin-transform-modules-commonjs` and set `@babel/preset-env` to `"modules": false` which i _think_ now will export just the ES syntax. 

If you give this a pull and run `yarn build` and have a look at the `dist` folder the exported code looks much more like the kinda thing we'd write.

Also made a small change to `tsconfig` as i was exporting the types to a `types` dir but wasn't point the `declarationDir ` at that dir so we would have proabably had a "types not found" error if we'd tried to use the package in a TypeScirpt project.
