### PR TITLE
bug/404-page

### DIFF
--- a/packages/gatsby-plugin-mdx-embed/src/pages/404.js
+++ b/packages/gatsby-plugin-mdx-embed/src/pages/404.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const NotFoundPage = () => <h1>Not Found</h1>;
-
-export default NotFoundPage;


### PR DESCRIPTION
- remove src/pages from gatsby-plugin-mdx-embed

This PR relates to [#83] no errors even after removing the `src/pages` dir which i think is what we want right?