### PR TITLE
Add 'lerna bootstrap' as a post-install step

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "postinstall": "lerna bootstrap",
     "prettier": "yarn workspace mdx-embed prettier && yarn workspace gatsby-plugin-mdx-embed prettier && yarn workspace docs prettier",
     "lint": "yarn workspace mdx-embed lint",
     "lint:fix": "yarn workspace mdx-embed lint:fix",


### PR DESCRIPTION
This PR fixes the build failing as a result of package dependencies not being installed after running `npm install` from the top-level package.json.

While this PR fixes the workspace not being installed if not using yarn, the scripts all require using yarn. Maybe `"useWorkspaces": true` should be set in the [`lerna.json` file](https://github.com/JeffersonBledsoe/mdx-embed/blob/2d698b7aef2a7acf6b9c65581559a8154080e2fb/lerna.json#L13), along with setting the npmClient and adding the `docs` and `examples` directories as packages in `lerna.json`? I'm happy to do another PR with this fix so it all runs out the box with both yarn and npm if this gets merged 🙂 

Closes #146