### PR TITLE
test(YouTube): Add integration test

### DIFF
--- a/cypress/integration/youtube.spec.js
+++ b/cypress/integration/youtube.spec.js
@@ -9,13 +9,4 @@ context('<YouTube />', () => {
     getIframeBody().find('.ytp-title-text').should('not.be.undefined');
     getIframeBody().find('.ytp-large-play-button').should('not.be.undefined');
   });
-
-  it('it successfully plays a video', () => {
-    cy.visit('/iframe.html?id=components-youtube--usage&viewMode=story');
-    getIframeBody().find('#player').should('not.be.undefined');
-    // getIframeBody().find('.ytp-large-play-button').should('not.be.undefined');
-    getIframeBody().find('.ytp-large-play-button').click();
-    getIframeBody().find('.ytp-error-icon-container').should('be.undefined');
-    getIframeBody().get('.ytp-chrome-bottom').should('not.be.undefined');
-  });
 });

--- a/cypress/integration/youtube.spec.js
+++ b/cypress/integration/youtube.spec.js
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+
+import { getIframeBody } from '../support/commands';
+
+context('<YouTube />', () => {
+  it('it loads youtube video correctly', () => {
+    cy.visit('/iframe.html?id=components-youtube--usage&viewMode=story');
+    getIframeBody().find('#player').should('not.be.undefined');
+    getIframeBody().find('.ytp-title-text').should('not.be.undefined');
+    getIframeBody().find('.ytp-large-play-button').should('not.be.undefined');
+  });
+
+  it('it successfully plays a video', () => {
+    cy.visit('/iframe.html?id=components-youtube--usage&viewMode=story');
+    getIframeBody().find('#player').should('not.be.undefined');
+    // getIframeBody().find('.ytp-large-play-button').should('not.be.undefined');
+    getIframeBody().find('.ytp-large-play-button').click();
+    getIframeBody().find('.ytp-error-icon-container').should('be.undefined');
+    getIframeBody().get('.ytp-chrome-bottom').should('not.be.undefined');
+  });
+});

--- a/packages/mdx-embed/src/components/youtube/youtube.tsx
+++ b/packages/mdx-embed/src/components/youtube/youtube.tsx
@@ -41,6 +41,7 @@ export const YouTube: FunctionComponent<IYouTubeProps> = ({
         }}
       >
         <iframe
+          data-testid={`youTube-${youTubeId}`}
           title={`youTube-${youTubeId}`}
           src={`https://www.youtube.com/embed/${youTubeId}?&autoplay=${autoPlay}&start=${startTime}`}
           frameBorder="0"

--- a/packages/mdx-embed/src/components/youtube/youtube.tsx
+++ b/packages/mdx-embed/src/components/youtube/youtube.tsx
@@ -41,7 +41,6 @@ export const YouTube: FunctionComponent<IYouTubeProps> = ({
         }}
       >
         <iframe
-          data-testid={`youTube-${youTubeId}`}
           title={`youTube-${youTubeId}`}
           src={`https://www.youtube.com/embed/${youTubeId}?&autoplay=${autoPlay}&start=${startTime}`}
           frameBorder="0"


### PR DESCRIPTION
Adds tests for the following:
- [x] The YouTube iframe displaying
- [ ] A valid id prop being passed doesn't produce a video error

Closes #130 
