### PR TITLE
test: Add soundcloud unit tests - it closes #113

### DIFF
--- a/packages/mdx-embed/src/components/soundcloud/soundcloud.test.tsx
+++ b/packages/mdx-embed/src/components/soundcloud/soundcloud.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect'
+
+import { SoundCloud } from './';
+
+describe('<SoundCloud />', () => {
+  beforeEach(() => {
+    (window as any).addIntersectionObserver();
+  });
+
+  test('it renders the component when provided a soundCloudLink', () => {
+    render(<SoundCloud soundCloudLink="tracks/499997862" />);
+
+    act(() => {
+      (window as any).triggerGeneralObserver();
+      return undefined;
+    })
+
+    expect(screen.getByTestId('soundcloud')).toBeDefined();
+  })
+
+  test('it renders the component with color defined', () => {
+    render(<SoundCloud soundCloudLink="tracks/188189839" color="e23f88" />);
+
+    act(() => {
+      (window as any).triggerGeneralObserver();
+      return undefined;
+    })
+
+    expect(screen.getByTestId('soundcloud')).toBeDefined();
+    expect(screen.getByTestId('soundcloud')).toHaveAttribute('src', expect.stringContaining('e23f88'))
+  })
+
+  test('it renders the component with visual artwork', () => {
+    render(<SoundCloud soundCloudLink="tracks/196287837" visual={true} width="300px" height="300px" />);
+
+    act(() => {
+      (window as any).triggerGeneralObserver();
+      return undefined;
+    })
+
+    expect(screen.getByTestId('soundcloud')).toBeDefined();
+    expect(screen.getByTestId('soundcloud')).toHaveAttribute('src', expect.stringContaining('visual=true'))
+    expect(screen.getByTestId('soundcloud')).toHaveAttribute('height', expect.stringContaining('300px'))
+    expect(screen.getByTestId('soundcloud')).toHaveAttribute('width', expect.stringContaining('300px'))
+  })
+});

--- a/packages/mdx-embed/src/components/soundcloud/soundcloud.test.tsx
+++ b/packages/mdx-embed/src/components/soundcloud/soundcloud.test.tsx
@@ -28,8 +28,10 @@ describe('<SoundCloud />', () => {
       return undefined;
     })
 
-    expect(screen.getByTestId('soundcloud')).toBeDefined();
-    expect(screen.getByTestId('soundcloud')).toHaveAttribute('src', expect.stringContaining('e23f88'))
+    const soundCloud = screen.getByTestId('soundcloud')
+
+    expect(soundCloud).toBeDefined();
+    expect(soundCloud).toHaveAttribute('src', expect.stringContaining('e23f88'))
   })
 
   test('it renders the component with visual artwork', () => {
@@ -40,9 +42,11 @@ describe('<SoundCloud />', () => {
       return undefined;
     })
 
-    expect(screen.getByTestId('soundcloud')).toBeDefined();
-    expect(screen.getByTestId('soundcloud')).toHaveAttribute('src', expect.stringContaining('visual=true'))
-    expect(screen.getByTestId('soundcloud')).toHaveAttribute('height', expect.stringContaining('300px'))
-    expect(screen.getByTestId('soundcloud')).toHaveAttribute('width', expect.stringContaining('300px'))
+    const soundCloud = screen.getByTestId('soundcloud')
+
+    expect(soundCloud).toBeDefined();
+    expect(soundCloud).toHaveAttribute('src', expect.stringContaining('visual=true'))
+    expect(soundCloud).toHaveAttribute('height', expect.stringContaining('300px'))
+    expect(soundCloud).toHaveAttribute('width', expect.stringContaining('300px'))
   })
 });

--- a/packages/mdx-embed/src/components/soundcloud/soundcloud.tsx
+++ b/packages/mdx-embed/src/components/soundcloud/soundcloud.tsx
@@ -26,6 +26,7 @@ export const SoundCloud: FunctionComponent<ISoundCloudProps> = ({
 }: ISoundCloudProps) => (
   <GeneralObserver>
     <iframe
+      data-testid="soundcloud"
       title={`sound-cloud-${soundCloudLink}`}
       className="soundcloud-mdx-embed"
       width={width}


### PR DESCRIPTION
Soundcloud unit tests account for color and visual artwork cases.