### PR TITLE
test: add pinterest unit tests

### DIFF
--- a/packages/mdx-embed/src/components/pinterest/pin.test.tsx
+++ b/packages/mdx-embed/src/components/pinterest/pin.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+
+import { Pin } from './';
+
+describe('<Pin />', () => {
+  beforeEach(() => {
+    (window as any).addIntersectionObserver();
+  });
+
+  test('it renders the component', () => {
+    const pinId = '637963103444140543';
+    render(<Pin pinId={pinId} size="medium"/>);
+
+    act(() => {
+      (window as any).triggerGeneralObserver();
+      return undefined;
+    });
+
+    expect(screen.getByTestId('pin')).toBeDefined();
+  });
+});

--- a/packages/mdx-embed/src/components/pinterest/pin.tsx
+++ b/packages/mdx-embed/src/components/pinterest/pin.tsx
@@ -12,6 +12,7 @@ export const Pin: FunctionComponent<IPinProps> = ({ pinId, size = 'small' }: IPi
   <GeneralObserver onEnter={() => handlePinterestBuild()}>
     <a
       className="pinterest-pin pinterest-pin-mdx-embed"
+      data-testid="pin"
       data-pin-do="embedPin"
       data-pin-width={size}
       href={`https://www.pinterest.com/pin/${pinId}`}

--- a/packages/mdx-embed/src/components/pinterest/pinterest-board.test.tsx
+++ b/packages/mdx-embed/src/components/pinterest/pinterest-board.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+
+import { PinterestBoard } from './';
+
+const pinterestLink = 'fromspacewithlove/astronauts/';
+
+describe('<PinterestBoard />', () => {
+  beforeEach(() => {
+    (window as any).addIntersectionObserver();
+  });
+
+  test('it renders the component', () => {
+    render(<PinterestBoard pinterestLink={pinterestLink} />);
+
+    act(() => {
+      (window as any).triggerGeneralObserver();
+      return undefined;
+    });
+
+    expect(screen.getByTestId('pinterest-board')).toBeDefined();
+  });
+
+  test('it renders the component with given width', () => {
+    render(<PinterestBoard pinterestLink={pinterestLink} width={600} />);
+
+    act(() => {
+      (window as any).triggerGeneralObserver();
+      return undefined;
+    });
+
+    expect(screen.getByTestId('pinterest-board')).toBeDefined();
+  });
+
+  test('it renders the component with given variant', () => {
+    render(<PinterestBoard pinterestLink={pinterestLink} variant="user" />);
+
+    act(() => {
+      (window as any).triggerGeneralObserver();
+      return undefined;
+    });
+
+    expect(screen.getByTestId('pinterest-board')).toBeDefined();
+  });
+
+});

--- a/packages/mdx-embed/src/components/pinterest/pinterest-board.tsx
+++ b/packages/mdx-embed/src/components/pinterest/pinterest-board.tsx
@@ -24,6 +24,7 @@ export const PinterestBoard: FunctionComponent<IPinterestBoardProps> = ({
   <GeneralObserver onEnter={() => handlePinterestBuild()}>
     <a
       className="pinterest-board pinterest-board-mdx-embed"
+      data-testid="pinterest-board"
       data-pin-do={`embed${variant.charAt(0).toUpperCase()}${variant.slice(1)}`}
       data-pin-board-width={width}
       data-pin-scale-height={height}

--- a/packages/mdx-embed/src/components/pinterest/pinterest-follow-button.test.tsx
+++ b/packages/mdx-embed/src/components/pinterest/pinterest-follow-button.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+
+import { PinterestFollowButton } from './';
+
+describe('<PinterestFollowButton />', () => {
+  beforeEach(() => {
+    (window as any).addIntersectionObserver();
+  });
+
+  test('it renders the component', () => {
+    const pinId = 'pauliescanlon80';
+    render(<PinterestFollowButton username={pinId} />);
+
+    act(() => {
+      (window as any).triggerGeneralObserver();
+      return undefined;
+    });
+
+    expect(screen.getByTestId('pinterest-follow-button')).toBeDefined();
+  });
+});

--- a/packages/mdx-embed/src/components/pinterest/pinterest-follow-button.tsx
+++ b/packages/mdx-embed/src/components/pinterest/pinterest-follow-button.tsx
@@ -12,6 +12,7 @@ export const PinterestFollowButton: FunctionComponent<IPinterestFollowButtonProp
   <GeneralObserver onEnter={() => handlePinterestBuild()}>
     <a
       className="pinterest-follow-button pinterest-follow-button-mdx-embed"
+      data-testid="pinterest-follow-button"
       data-pin-do="buttonFollow"
       href={`https://www.pinterest.com/${username}/`}
     >


### PR DESCRIPTION
This PR adds unit tests for the Pin, PinterestBoard and PinterestFollowButton components.

Closes #109 