### PR TITLE
Add className to general observer div

### DIFF
--- a/packages/mdx-embed/src/components/general-observer/general-observer.tsx
+++ b/packages/mdx-embed/src/components/general-observer/general-observer.tsx
@@ -30,7 +30,7 @@ export const GeneralObserver: FunctionComponent<IGeneralObserverProps> = ({ chil
   }, [ref]);
 
   return (
-    <div ref={ref as RefObject<HTMLDivElement>} data-testid="general-observer">
+    <div ref={ref as RefObject<HTMLDivElement>} data-testid="general-observer" className="mdx-embed">
       {isChildVisible ? children : <div style={{ height, width: '100%' }} />}
     </div>
   );


### PR DESCRIPTION
Add a better way to target the wrapping div with CSS. 

I'm currently using the `data-testid` to target the wrapping div, but that's cumbersome to target with CSS and that really only should be used for testing.