### PR TITLE
Tests/various integration tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,6 @@
   "defaultCommandTimeout": 6000,
   "viewportWidth": 1000,
   "viewportHeight": 568,
-  "video": false
+  "video": false,
+  "chromeWebSecurity": false
 }

--- a/cypress/integration/airtable.spec.js
+++ b/cypress/integration/airtable.spec.js
@@ -1,38 +1,34 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<AirtableBase />', () => {
   it('it loads airtable base correctly', () => {
     cy.visit('/iframe.html?id=components-airtable-airtablebase--usage&viewMode=story');
-    getIframeBody().find('#applicationContainer').should('not.be.undefined')
-    getIframeBody().find('#table').should('not.be.undefined')
-    getIframeBody().find('#view').should('not.be.undefined')
-    getIframeBody().find('#searchButton').should('not.be.undefined')
+    cy.getIframeBody().find('#applicationContainer').should('not.be.undefined')
+    cy.getIframeBody().find('#table').should('not.be.undefined')
+    cy.getIframeBody().find('#view').should('not.be.undefined')
+    cy.getIframeBody().find('#searchButton').should('not.be.undefined')
   })
 
   it('it loads airtable base without controls', () => {
     cy.visit('/iframe.html?id=components-airtable-airtablebase--controls&viewMode=story')
-    getIframeBody().find('#applicationContainer').should('not.be.undefined')
-    getIframeBody().find('#table').should('not.be.undefined')
-    getIframeBody().find('#table .viewBarContainer').should('not.exist')
+    cy.getIframeBody().find('#applicationContainer').should('not.be.undefined')
+    cy.getIframeBody().find('#table').should('not.be.undefined')
+    cy.getIframeBody().find('#table .viewBarContainer').should('not.exist')
   })
 
   it('it loads airtable base with card layout', () => {
     cy.visit('/iframe.html?id=components-airtable-airtablebase--layout&viewMode=story')
-    getIframeBody().find('#applicationContainer').should('not.be.undefined')
-    getIframeBody().find('#table').should('not.be.undefined')
-    getIframeBody().find('#gridViewWithCardLayout').should('not.be.undefined')
+    cy.getIframeBody().find('#applicationContainer').should('not.be.undefined')
+    cy.getIframeBody().find('#table').should('not.be.undefined')
+    cy.getIframeBody().find('#gridViewWithCardLayout').should('not.be.undefined')
   })
 })
 
 context('<AirtableForm />', () => {
   it('it loads airtable form correctly', () => {
     cy.visit('/iframe.html?id=components-airtable-airtableform--usage&viewMode=story');
-     getIframeBody().find('#hyperbaseContainer').should('not.be.undefined')
-     getIframeBody().find('.formContent').should('not.be.undefined')
-     getIframeBody().find('.submitButton').should('not.be.undefined')
+     cy.getIframeBody().find('#hyperbaseContainer').should('not.be.undefined')
+     cy.getIframeBody().find('.formContent').should('not.be.undefined')
+     cy.getIframeBody().find('.submitButton').should('not.be.undefined')
   })
 })
-
-

--- a/cypress/integration/buzzsprout.spec.js
+++ b/cypress/integration/buzzsprout.spec.js
@@ -1,13 +1,11 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<Buzzsprout />', () => {
   it('it loads buzzsprout player widget', () => {
     cy.visit('/iframe.html?id=components-buzzsprout--usage&viewMode=story');
     cy.get('[data-testId="buzzsprout"]').should('not.be.undefined');
-    getIframeBody().find('.buzzsprout-player').should('not.be.undefined');
-    getIframeBody().find('.artwork-container').should('not.be.undefined');
-    getIframeBody().find('.episode-container').should('not.be.undefined');
+    cy.getIframeBody().find('.buzzsprout-player').should('not.be.undefined');
+    cy.getIframeBody().find('.artwork-container').should('not.be.undefined');
+    cy.getIframeBody().find('.episode-container').should('not.be.undefined');
   });
 });

--- a/cypress/integration/cinnamon.spec.js
+++ b/cypress/integration/cinnamon.spec.js
@@ -1,0 +1,14 @@
+/// <reference types="cypress" />
+
+context('<Cinnamon />', () => {
+  it('it loads cinnamon video and controls', () => {
+    cy.visit('/iframe.html?id=components-cinnamon--usage&viewMode=story');
+
+    cy.getIframeBody().find('video').should('exist'); // The video
+    cy.getIframeBody().find('div[class*="BarContainer"]').should('exist'); // The playback scroll bar
+    cy.getIframeBody().find('div[class*="ControlContainer"]').should('exist'); // The control (buttons, volume) bar
+
+    // Sanity test to make sure the tests actually work
+    cy.getIframeBody().find('div[class*="ShouldNotExist"]').should('not.exist');
+  });
+});

--- a/cypress/integration/codepen.spec.js
+++ b/cypress/integration/codepen.spec.js
@@ -1,12 +1,11 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<CodePen />', () => {
   it('it loads codeopen nav, output and footer', () => {
     cy.visit('/iframe.html?id=components-codepen--usage&viewMode=story');
-    getIframeBody().find('#embed-nav').should('not.be.undefined');
-    getIframeBody().find('#output').should('not.be.undefined');
-    getIframeBody().find('#embed-footer').should('not.be.undefined');
+
+    cy.getIframeBody().find('#embed-nav').should('exist');
+    cy.getIframeBody().find('#output').should('exist');
+    cy.getIframeBody().find('#embed-footer').should('exist');
   });
 });

--- a/cypress/integration/codesandbox.spec.js
+++ b/cypress/integration/codesandbox.spec.js
@@ -1,13 +1,11 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<CodeSandbox />', () => {
   it('it loads codesandbox iframe', () => {
     cy.visit('/iframe.html?id=components-codesandbox--usage&viewMode=story');
     cy.get('[data-testid="codesandbox"]').should('not.be.undefined');
-    getIframeBody().find('#embed-nav').should('not.be.undefined');
-    getIframeBody().find('#output').should('not.be.undefined');
-    getIframeBody().find('#embed-footer').should('not.be.undefined');
+    cy.getIframeBody().find('#embed-nav').should('not.be.undefined');
+    cy.getIframeBody().find('#output').should('not.be.undefined');
+    cy.getIframeBody().find('#embed-footer').should('not.be.undefined');
   });
 });

--- a/cypress/integration/egghead-lesson.spec.js
+++ b/cypress/integration/egghead-lesson.spec.js
@@ -1,17 +1,15 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('Egghead Lesson', () => {
   it('it loads egghead lesson player', () => {
     cy.visit('/iframe.html?id=components-egghead-eggheadlesson--usage&viewMode=story');
     cy.get(
       '[data-testId="egghead-gatsby-set-up-a-gatsby-site-to-use-mdx-with-gatsby-plugin-mdx-with-a-default-layout"]',
     ).should('not.be.undefined');
-    getIframeBody()
+    cy.getIframeBody()
       .find('#egghead-set-up-a-gatsby-site-to-use-mdx-with-gatsby-plugin-mdx-with-a-default-layout-HyV65y0XI')
       .should('not.be.undefined');
-    getIframeBody()
+    cy.getIframeBody()
       .find(
         '#bitmovinplayer-video-egghead-set-up-a-gatsby-site-to-use-mdx-with-gatsby-plugin-mdx-with-a-default-layout-HyV65y0XI',
       )

--- a/cypress/integration/gist.spec.js
+++ b/cypress/integration/gist.spec.js
@@ -1,7 +1,5 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<Gist />', () => {
   it('it loads gist embed', () => {
     cy.visit('/iframe.html?id=components-gist--usage&viewMode=story');

--- a/cypress/integration/lbry.spec.js
+++ b/cypress/integration/lbry.spec.js
@@ -1,10 +1,8 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<Lbry />', () => {
   it('it loads Lbry player widget', () => {
     cy.visit('/iframe.html?id=components-lbry--usage&viewMode=story');
-    getIframeBody().find('.lbry-player').should('not.be.undefined');
+    cy.getIframeBody().find('.lbry-player').should('not.be.undefined');
   });
 });

--- a/cypress/integration/simplecast-episode.spec.js
+++ b/cypress/integration/simplecast-episode.spec.js
@@ -1,10 +1,8 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<SimplecastEpisode />', () => {
   it('it loads SimplecastEpisode player', () => {
     cy.visit('/iframe.html?id=components-simplecast-simplecastepisode--usage&viewMode=story');
-    getIframeBody().find('.simplecast-player').should('not.be.undefined');
+    cy.getIframeBody().find('.simplecast-player').should('not.be.undefined');
   });
 });

--- a/cypress/integration/soundcloud.spec.js
+++ b/cypress/integration/soundcloud.spec.js
@@ -1,19 +1,17 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<SoundCloud />', () => {
   it('it loads soundcloud correctly', () => {
     cy.visit('/iframe.html?id=components-soundcloud--usage&viewMode=story');
-    getIframeBody().find('#widget').should('not.be.undefined');
-    getIframeBody().find('.soundContainer').should('not.be.undefined');
-    getIframeBody().find('.playButton').should('not.be.undefined');
+    cy.getIframeBody().find('#widget').should('not.be.undefined');
+    cy.getIframeBody().find('.soundContainer').should('not.be.undefined');
+    cy.getIframeBody().find('.playButton').should('not.be.undefined');
   })
 
   it('it loads soundcloud with visual artwork', () => {
     cy.visit('http://localhost:6006/iframe.html?id=components-soundcloud--visual&viewMode=story');
-    getIframeBody().find('#widget').should('not.be.undefined');
-    getIframeBody().find('.visualSoundContainer').should('not.be.undefined');
-    getIframeBody().find('.sc-artwork').should('not.be.undefined');
+    cy.getIframeBody().find('#widget').should('not.be.undefined');
+    cy.getIframeBody().find('.visualSoundContainer').should('not.be.undefined');
+    cy.getIframeBody().find('.sc-artwork').should('not.be.undefined');
   })
 })

--- a/cypress/integration/vimeo.spec.js
+++ b/cypress/integration/vimeo.spec.js
@@ -1,12 +1,10 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<Vimeo />', () => {
   it('it loads vimeo player, title and controls', () => {
     cy.visit('/iframe.html?id=components-vimeo--usage&viewMode=story');
-    getIframeBody().find('#player').should('not.be.undefined');
-    getIframeBody().find('.vp-controls').should('not.be.undefined');
-    getIframeBody().find('.vp-title-header').should('not.be.undefined');
+    cy.getIframeBody().find('#player').should('not.be.undefined');
+    cy.getIframeBody().find('.vp-controls').should('not.be.undefined');
+    cy.getIframeBody().find('.vp-title-header').should('not.be.undefined');
   });
 });

--- a/cypress/integration/youtube.spec.js
+++ b/cypress/integration/youtube.spec.js
@@ -1,12 +1,10 @@
 /// <reference types="cypress" />
 
-import { getIframeBody } from '../support/commands';
-
 context('<YouTube />', () => {
   it('it loads youtube video correctly', () => {
     cy.visit('/iframe.html?id=components-youtube--usage&viewMode=story');
-    getIframeBody().find('#player').should('not.be.undefined');
-    getIframeBody().find('.ytp-title-text').should('not.be.undefined');
-    getIframeBody().find('.ytp-large-play-button').should('not.be.undefined');
+    cy.getIframeBody().find('#player').should('not.be.undefined');
+    cy.getIframeBody().find('.ytp-title-text').should('not.be.undefined');
+    cy.getIframeBody().find('.ytp-large-play-button').should('not.be.undefined');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,11 +1,3 @@
-const getIframeDocument = () => {
-  return cy.get('iframe').its('0.contentDocument').should('not.be.empty');
-};
-
-const getIframeBody = () => {
-  return cy.get('iframe').its('0.contentDocument.body').then(cy.wrap);
-};
-
 Cypress.Commands.add('getIframeBody', () => {
   cy.log('getIframeBody')
 
@@ -14,5 +6,3 @@ Cypress.Commands.add('getIframeBody', () => {
   .its('0.contentDocument.body', { log: false }).should('not.be.empty')
   .then((body) => cy.wrap(body, { log: false }))
 });
-
-export { getIframeBody };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,7 +1,18 @@
 const getIframeDocument = () => {
-  return cy.get('iframe').its('0.contentDocument').should('exist');
+  return cy.get('iframe').its('0.contentDocument').should('not.be.empty');
 };
 
-export const getIframeBody = () => {
-  return getIframeDocument().its('body').should('not.be.undefined').then(cy.wrap);
+const getIframeBody = () => {
+  return cy.get('iframe').its('0.contentDocument.body').then(cy.wrap);
 };
+
+Cypress.Commands.add('getIframeBody', () => {
+  cy.log('getIframeBody')
+
+  return cy
+  .get('iframe', { log: false })
+  .its('0.contentDocument.body', { log: false }).should('not.be.empty')
+  .then((body) => cy.wrap(body, { log: false }))
+});
+
+export { getIframeBody };


### PR DESCRIPTION
This is a big one...it fixes the false positives on the cypress integration tests and adds the getIframeBody() as a cypress command, so now we no longer have to import the function but rather have it readily available as a `cy` method.

I did a quick find and replace in the integration folder and all the tests, save for one, still pass. The one that does not pass - I have to wonder if it's not a false positive, because checking the actual iframe, the element **is** in the DOM so the test cannot pass. But I must admit I have never worked with airtable so I have no way of knowing for sure if this is correct or not. :( 