### PR TITLE
Add types to package.json

### DIFF
--- a/packages/mdx-embed/package.json
+++ b/packages/mdx-embed/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.16",
   "description": "Embed 3rd party media content in MDX - no import required",
   "main": "dist/index.js",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "prettier": "prettier --config ../../.prettierrc.js --ignore-path ../../.prettierignore --write \"**/*.{json,js,ts,tsx}\"",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
Hello!

This PR should fix #216 I'm assuming that this is all that needs to be done?

I'd like to check with you if the path is the right one, I've used the one you mentioned on the open issue, but on the [publishing page](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package) they use `"types": "./lib/main.d.ts"`  🤔 

Let me know if you would like me to add/change anything to the PR 😄 👍 