### PR TITLE
chore: allow to use react from v16

### DIFF
--- a/packages/mdx-embed/package.json
+++ b/packages/mdx-embed/package.json
@@ -78,7 +78,7 @@
   "peerDependencies": {
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.x || ^17.x || ^18.x",
+    "react-dom": "^16.x || ^17.x || ^18.x"
   }
 }


### PR DESCRIPTION
This change allows resolving react dependencies for the current project without npm vulnerabilities