### PR TITLE
feat: Add option to hide FIgma UI

### DIFF
--- a/packages/mdx-embed/src/components/figma/figma.tsx
+++ b/packages/mdx-embed/src/components/figma/figma.tsx
@@ -12,9 +12,13 @@ export interface IFigmaProps {
    * The url to the file or frame. Make sure to include the node-id if present
    */
   url: string;
+  /**
+   * Show Figma UI
+   */
+  showUI: boolean;
 }
 
-export const Figma: FunctionComponent<IFigmaProps> = ({ title, height = 450, url }: IFigmaProps) => {
+export const Figma: FunctionComponent<IFigmaProps> = ({ title, height = 450, url, showUI = true }: IFigmaProps) => {
   const regex = /(file|proto)\/([0-9a-zA-Z]{22,128})(?:\/.*)?$/;
   if (!regex.test(url)) {
     return null;
@@ -30,7 +34,7 @@ export const Figma: FunctionComponent<IFigmaProps> = ({ title, height = 450, url
           width: '100%',
         }}
         scrolling="no"
-        src={`https://www.figma.com/embed?embed_host=mdx-embed&url=https://www.figma.com/${url}`}
+        src={`https://www.figma.com/embed?embed_host=mdx-embed&show_ui=${showUI ? 1 : 0}&url=https://www.figma.com/${url}`}
         frameBorder="no"
         allowFullScreen
       />


### PR DESCRIPTION
Figma embeds also support an option to hide embed UI.

It's a simple change and would love to see it included by default in the mdx-embed package.

Let me know, if there is anything i can do to improve the pull-request.